### PR TITLE
Fix Testing for Compliance

### DIFF
--- a/SIMP/compliance_profiles/CentOS/7/mapping.yaml
+++ b/SIMP/compliance_profiles/CentOS/7/mapping.yaml
@@ -137,7 +137,7 @@ checks:
       nist_800_53:rev4:AC-7: true
     type: puppet-class-parameter
     settings:
-      parameter: "pam::deny"
+      parameter: "pam::fail_interval"
       value: 900
   "puppet.forge.simp.pam.homedir_umask":
     controls:


### PR DESCRIPTION
This updates the mapping file to have the correct settings as fail_interval
was incorrect in the file.

Updates the compliance acceptance tests for ordering in the yaml file
per the compliance_markup documentation and adds support for reporting.